### PR TITLE
Issue: 2622834 by neetu, mouse movement being tracked

### DIFF
--- a/js/autologout.js
+++ b/js/autologout.js
@@ -46,6 +46,11 @@
           $(event.target).trigger('preventAutologout');
         });
 
+          // Bind formUpdated events to preventAutoLogout event.
+          $('body').bind('mousemove', function(event) {
+              $(event.target).trigger('preventAutologout');
+          });
+
         // Support for CKEditor.
         if (typeof CKEDITOR !== 'undefined') {
           CKEDITOR.on('instanceCreated', function(e) {


### PR DESCRIPTION
Activity was being set to TRUE only on Form updation and key pressing events happening(CKeditor). Triggered 'preventAutologout' on mouse movements as well.
