### PR TITLE
Add admin setting to disable user-specific logout thresholds

### DIFF
--- a/autologout.module
+++ b/autologout.module
@@ -33,9 +33,10 @@ function autologout_form_user_form_alter(&$form, FormStateInterface $form_state)
   $user_id = $form_state->getFormObject()->getEntity()->id();
   $access = FALSE;
 
-  // If user has access to change, and they are changing their own and only
-  // their own timeout. Or they are an admin.
-  if (($user->hasPermission('change own logout threshold') && $user->id() == $user_id) || $user->hasPermission('administer autologout')) {
+  // If user-specific thresholds are enabled (the default), and user has access
+  // to change and they are changing their own and only
+  // their own timeout, or they are an admin.
+  if (!\Drupal::config('autologout.settings')->get('no_individual_logout_threshold') && (($user->hasPermission('change own logout threshold') && $user->id() == $user_id) || $user->hasPermission('administer autologout'))) {
     $access = TRUE;
   }
 
@@ -83,7 +84,8 @@ function autologout_user_profile_submit(&$form, FormStateInterface $form_state) 
 
   // Access is reused here as a security measure. Not only will the element not
   // display but wont submit without access.
-  if ($access) {
+  // Do not store config if setting to not store config for every user is TRUE.
+  if ($access && !\Drupal::config('autologout.settings')->get('no_individual_logout_threshold')) {
     \Drupal::configFactory()->getEditable('autologout.user.' . $user_id)
       ->set('enabled', $enabled)
       ->set('timeout', $timeout)

--- a/src/Form/AutologoutSettingsForm.php
+++ b/src/Form/AutologoutSettingsForm.php
@@ -95,6 +95,14 @@ class AutologoutSettingsForm extends ConfigFormBase {
       '#description' => $this->t('How many seconds to give a user to respond to the logout dialog before ending their session.'),
     );
 
+    $form['no_individual_logout_threshold'] = array(
+      '#type' => 'checkbox',
+      '#title' => $this->t('Disable user-specific logout thresholds'),
+      '#default_value' => $config->get('no_individual_logout_threshold'),
+      '#weight' => -5,
+      '#description' => $this->t('Enable to only allow autologout thresholds to be set globally on this form. You may want to do this if...<br>1.) You don\'t plan on allowing users to set their own logout threshold.<br>2.) You don\'t allow writing to the config directory in your production environment and still want autologout admins to be able to create or edit users.'),
+    );
+
     $form['role_logout'] = array(
       '#type' => 'checkbox',
       '#title' => $this->t('Role Timeout'),
@@ -289,6 +297,7 @@ class AutologoutSettingsForm extends ConfigFormBase {
     $autologout_settings->set('timeout', $values['timeout'])
       ->set('max_timeout', $values['max_timeout'])
       ->set('padding', $values['padding'])
+      ->set('no_individual_logout_threshold', $values['no_individual_logout_threshold'])
       ->set('role_logout', $values['role_logout'])
       ->set('redirect_url', $values['redirect_url'])
       ->set('no_dialog', $values['no_dialog'])


### PR DESCRIPTION
If setting is TRUE, autologout threshold text field is hidden from the user edit form
and the form does not set a autologout.user.uid configuration item on submit.

**Motivation**
Currently when an admin saves a user with autologout enabled configuration is written for each user's individual logout threshold.

This not only reduces the module's footprint, but allows for workflows where configuration changes should not be made on the production environment; only on staging or local environments.

Certain hosting providers (e.g. Pantheon) don't allow config to be written unless the site is flipped from (default) git mode into sftp mode, which means with autologout enabled users wouldn't be able to be saved.

Related drupal.org issue: https://www.drupal.org/node/2730737
